### PR TITLE
Implement JSON parsing error handling in llm_async_processor.py

### DIFF
--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -9,19 +9,19 @@ testmode: true
 inference_interval: 0 # seconds
 
 run:
-  jaster: false
-  jmmlu_robustness: false # if this is set as true, jaster should set as true
-  mtbench: false
-  jbbq: false
-  toxicity: false
-  jtruthfulqa: false
-  hle: false
-  swebench: false
+  jaster: true
+  jmmlu_robustness: true # if this is set as true, jaster should set as true
+  mtbench: true
+  jbbq: true
+  toxicity: true
+  jtruthfulqa: true
+  hle: true
+  swebench: true
   bfcl: true
-  hallulens: false
-  arc_agi_2: false
-  m_ifeval: false
-  aggregate: false
+  hallulens: true
+  arc_agi_2: true
+  m_ifeval: true
+  aggregate: true
 
 model:
   artifact_path: null


### PR DESCRIPTION
## Add JSON parsing error retry for evaluation scoring

### What this PR does
Adds automatic retry functionality when JSON parsing errors occur during model evaluation scoring.

### Why this change is needed
- The evaluation process sometimes fails due to incomplete JSON responses from OpenAI API
- Examples of errors encountered:
  - `Invalid JSON: EOF while parsing a string at line 1 column 22`
  - `Invalid JSON: EOF while parsing an object at line 2 column 0`
- These are typically transient network or API issues that can be resolved with a retry

### Changes made
- Added `pydantic_core.ValidationError` to the retry exceptions in `llm_async_processor.py`
- The existing backoff decorator now handles JSON parsing errors with:
  - Max 50 retry attempts
  - Exponential backoff with jitter
  - 30-minute timeout
- Added logging to track when JSON parsing errors occur and retries are attempted

### Impact
- No changes to existing functionality
- Only affects error handling during evaluation scoring
- Makes the evaluation process more robust against transient API issues

### Test
[W&B Run](https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev/runs/pfeios9d)