### PR TITLE
Use LLMAsyncProcessor for BFCL OpenAI Handler

### DIFF
--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/_llm_response_generation.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/_llm_response_generation.py
@@ -291,8 +291,13 @@ def generate_results(args, model_name, test_cases_total):
     update_mode = True
     handler = build_handler(model_name, args.temperature)
 
-    if handler.model_style == ModelStyle.OSSMODEL:
-        handler.setup_tokenizer(args.local_model_path)
+    ## 暫定: AsyncLLMProcessor対応済みハンドラーはasync実行
+    if handler.model_style == ModelStyle.OSSMODEL or type(handler).__name__ in [
+        "OpenAICompletionsHandler",
+        "OpenAIResponsesHandler",
+    ]:
+        if hasattr(handler, "setup_tokenizer"):
+            handler.setup_tokenizer(args.local_model_path)
         asyncio.run(async_generate_results(args, handler, test_cases_total))
     else:
         futures = []


### PR DESCRIPTION
## 変更内容

* OpenAIResponsesHandlerをLLMAsyncProcessor対応
* OpenAICompletionHandlerをLLMAsyncProcessor対応
* BFCLで各クライアント特有のレスポンス型を利用するために、LLMResponseクラスにraw_responseをそのまま渡すプロパティを追加

## Run

- Responses, Prompt https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev/runs/1fji8284
- Responses, FC https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev/runs/spf9d5xq
- Completions, Prompt https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev/runs/ixgim78j
- Completions, FC https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev/runs/ts4ma17f