### PR TITLE
feat: Add native Anthropic API support with thinking tokens

### DIFF
--- a/configs/config-anthropic-claude-sonnet-4.yaml
+++ b/configs/config-anthropic-claude-sonnet-4.yaml
@@ -1,0 +1,15 @@
+wandb:
+  run_name: "anthropic/claude-sonnet-4-20250514:extended-thinking"
+
+api: "anthropic"
+batch_size: 32
+
+model:
+  pretrained_model_name_or_path: claude-sonnet-4-20250514 #if you use openai api, put the name of model
+  bfcl_model_id: claude-sonnet-4-20250514-FC # check the model name in "llm-leaderboard/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md"
+  size_category: api
+  size: null
+  release_date: 5/14/2025
+  thinking:  # Anthropic純正仕様
+    type: enabled
+    budget_tokens: 16384


### PR DESCRIPTION
## 概要
このPRでは、AnthropicのClaudeモデルに対する純正APIサポートとthinking tokens機能を追加し、評価システムがClaudeの内部推論機能を公式Anthropic API経由で利用できるようになります。

## 主な変更点

### 🔧 コア実装
- **新しい`AnthropicClient`クラス**: thinking parameter対応のAnthropic純正APIクライアント
- **Thinking設定**: `thinking.budget_tokens`パラメータのサポート
- **トークン計算**: 総トークン数の自動計算（回答用 + 推論予算）
- **Temperature要件**: thinking有効時に1.0に設定（Anthropic API要件）

### エラーハンドリング
- **エラー変換**: Anthropic固有の例外をOpenAI互換例外に変換
- **リトライ機構**: タイムアウト、レート制限、サーバーエラーに対する適切なバックオフ処理
- **例外マッピング**:
  - `anthropic.InternalServerError` → `openai.InternalServerError`
  - `anthropic.APITimeoutError` → `openai.APITimeoutError`
  - `anthropic.RateLimitError` → `openai.RateLimitError`
  - `anthropic.APIConnectionError` → `openai.APIConnectionError`

### ⚙️ 設定
- **純正API設定**: 直接Anthropic API使用のための`api: "anthropic"`
- **Thinkingパラメータ**: `thinking.type: "enabled"`と`thinking.budget_tokens`のサポート
- **モデル指定**: 純正API用の`claude-sonnet-4-20250514`形式

## 技術詳細

### トークン管理
```yaml
model:
  thinking:
    type: enabled
    budget_tokens: 16384  # 推論予算
```
- **総トークン数**: `answer_tokens + budget_tokens`
- **例**: 2048（回答用）+ 16384（推論用）= 18432（総計）

### API互換性
- 既存のOpenAI互換APIとの互換性を維持
- OpenRouter固有のreasoning token処理を元に戻し
- Anthropic純正API実装に特化

## テスト結果
- claude-sonnet-4: [W&B Run](https://wandb.ai/llm-leaderboard/nejumi-leaderboard4/runs/7zy81qx2)

## 設定例
```yaml
api: "anthropic"
model:
  pretrained_model_name_or_path: claude-sonnet-4-20250514
  thinking:
    type: enabled
    budget_tokens: 16384
```

## 破壊的変更
なし - 既存機能に影響しない追加機能です。

## 関連Issue
- Claude reasoning tokensのトークン不足問題を解決
- より良いパフォーマンスのためのAnthropic純正APIサポートを提供