### PR TITLE
Qwen3‑Max‑Preview（BFCL）対応とBlend再開の堅牢化（逐次DL・進捗表示・W&B API更新）

### DIFF
--- a/configs/config-qwen-qwen3-max.yaml
+++ b/configs/config-qwen-qwen3-max.yaml
@@ -1,0 +1,12 @@
+wandb:
+  run_name: Qwen/Qwen3-Max-Preview
+api: openai-compatible # openai, anthropic, google,..
+base_url: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+batch_size: 4
+model:
+  pretrained_model_name_or_path: qwen3-max-preview #if you use openai api, put the name of model
+  bfcl_model_id: "qwen3-max-preview-FC" # find id from "llm-leaderboard/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md"
+  base_model: "unknown"
+  size_category: api
+  size: null
+  release_date: 9/5/2025

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md
@@ -150,6 +150,8 @@ These unified handlers eliminate the need to configure individual model-specific
 | Qwen3-{30B-A3B,235B-A22B} (API)               | Prompt           | Qwen           | qwen3-{30b-a3b,235b-a22b}                                  |
 | QwQ-32B (API)                                  | Function Calling | Qwen           | qwq-32b-FC                                                 |
 | QwQ-32B (API)                                  | Prompt           | Qwen           | qwq-32b                                                    |
+| Qwen3-Max-Preview                              | Function Calling | Qwen           | qwen3-max-preview-FC                                       |
+| Qwen3-Max-Preview                              | Prompt           | Qwen           | qwen3-max-preview                                          |
 | Sky-T1-32B-Preview                             | Prompt           | Self-hosted 💻 | NovaSky-AI/Sky-T1-32B-Preview                               |
 | Snowflake/snowflake-arctic-instruct            | Prompt           | Snowflake      | snowflake/arctic                                            |
 | ThinkAgent-1B                                  | Function Calling | Self-hosted 💻 | ThinkAgents/ThinkAgent-1B                                   |

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/constants/model_config.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/constants/model_config.py
@@ -31,6 +31,7 @@ from ..model_handler.api_inference.qwen import (
     QwenAgentNoThinkHandler,
     QwenAgentThinkHandler,
     QwenAPIHandler,
+    QwenIntlAPIHandler,
 )
 from ..model_handler.api_inference.upstage import UpstageHandler
 from ..model_handler.api_inference.writer import WriterHandler
@@ -2184,6 +2185,30 @@ third_party_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
+    ),
+    "qwen3-max-preview-FC": ModelConfig(
+        model_name="qwen3-max-preview-FC",
+        display_name="Qwen3-Max-Preview (FC)",
+        url="https://help.aliyun.com/zh/model-studio/developer-reference/qwen-api",
+        org="Qwen",
+        license="Proprietary",
+        model_handler=QwenIntlAPIHandler,
+        input_price=60,  # Based on Alibaba Cloud Model Studio pricing
+        output_price=180,
+        is_fc_model=True,
+        underscore_to_dot=True,
+    ),
+    "qwen3-max-preview": ModelConfig(
+        model_name="qwen3-max-preview",
+        display_name="Qwen3-Max-Preview (Prompt)",
+        url="https://help.aliyun.com/zh/model-studio/developer-reference/qwen-api",
+        org="Qwen",
+        license="Proprietary",
+        model_handler=QwenIntlAPIHandler,
+        input_price=60,  # Based on Alibaba Cloud Model Studio pricing
+        output_price=180,
+        is_fc_model=False,
+        underscore_to_dot=False,
     ),
     # "katanemo/Arch-Agent-1.5B": ModelConfig(
     #     model_name="katanemo/Arch-Agent-1.5B",

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/api_inference/qwen.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/api_inference/qwen.py
@@ -289,4 +289,20 @@ class QwenAgentNoThinkHandler(QwenAPIHandler):
             stream_options={
                 "include_usage": True
             },
+        )
+
+
+class QwenIntlAPIHandler(QwenAPIHandler):
+    """
+    Qwen API handler for international DashScope API.
+    This handler uses the international endpoint for Qwen3-Max-Preview and other models.
+    Uses OPENAI_COMPATIBLE_API_KEY environment variable for API authentication.
+    """
+
+    def __init__(self, model_name, temperature) -> None:
+        super().__init__(model_name, temperature)
+        # Override the client to use international endpoint and correct API key
+        self.client = OpenAI(
+            base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+            api_key=os.getenv("OPENAI_COMPATIBLE_API_KEY"),  # Use OPENAI_COMPATIBLE_API_KEY for openai-compatible API
         ) 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,6 +1,7 @@
 import os
 import gc
 import json
+import time
 from typing import Any
 
 from huggingface_hub import HfApi
@@ -13,6 +14,95 @@ import questionary
 
 from config_singleton import WandbConfigSingleton
 
+
+@retry(stop=stop_after_attempt(8), wait=wait_fixed(5))
+def read_wandb_table_light(
+    table_name: str,
+    run: object,
+    run_path: str = None,
+    entity: str = None,
+    project: str = None,
+    run_id: str = None,
+    version: str = "latest",
+) -> pd.DataFrame:
+    """
+    軽量版: アーティファクト全体をダウンロードせず、必要な table.json のみ取得してDataFrame化する。
+
+    - Mediaや画像ファイルの実体は取得しない（参照のみ）。
+    - 大規模アーティファクトでもネットワーク負荷を最小化。
+    """
+    if run_path is not None:
+        entity, project, run_id = run_path.split("/")
+    elif entity is None or project is None or run_id is None:
+        entity = run.entity
+        project = run.project
+        run_id = run.id
+
+    artifact_path = f"{entity}/{project}/run-{run_id}-{table_name}:{version}"
+    artifact = run.use_artifact(artifact_path)
+
+    # 必要なJSONファイルだけを取得
+    table_json_path_ref = artifact.get_entry(f"{table_name}.table.json")
+    # 直接ファイルパスを返さない実装もあるため、ローカルに保存
+    from tempfile import TemporaryDirectory
+    with TemporaryDirectory() as tmpdir:
+        local_json_path = table_json_path_ref.download(root=tmpdir)
+        with open(local_json_path, "r") as f:
+            tjs = json.load(f)
+
+    # wandb.Tableを経由せず、直接DataFrame化してメディア解決を避ける
+    output_df = pd.DataFrame(data=tjs.get("data", []), columns=tjs.get("columns", []))
+    return output_df
+
+
+@retry(stop=stop_after_attempt(5), wait=wait_fixed(5))
+def read_wandb_table_throttled(
+    table_name: str,
+    run: object,
+    run_path: str = None,
+    entity: str = None,
+    project: str = None,
+    run_id: str = None,
+    version: str = "latest",
+    sleep_sec: float = 0.05,
+) -> pd.DataFrame:
+    """
+    すべてのアーティファクトファイルを順次ダウンロード（スロットル付き）した上で、テーブルを読み込む。
+    - ダウンロード内容は従来どおりフル（画像等を含む）だが、一括ではなく逐次取得して負荷を低減。
+    - blend run 専用での利用を想定。
+    """
+    if run_path is not None:
+        entity, project, run_id = run_path.split("/")
+    elif entity is None or project is None or run_id is None:
+        entity = run.entity
+        project = run.project
+        run_id = run.id
+
+    artifact_path = f"{entity}/{project}/run-{run_id}-{table_name}:{version}"
+    artifact = run.use_artifact(artifact_path)
+
+    # マニフェストに含まれる全ファイルを順次ダウンロード
+    entries = getattr(artifact, "manifest").entries
+    total_files = len(entries)
+    print(f"[blend] Starting sequential download: {artifact_path} ({total_files} files)")
+    from tempfile import TemporaryDirectory
+    with TemporaryDirectory() as tmpdir:
+        for idx, rel_path in enumerate(entries.keys(), start=1):
+            artifact.get_entry(rel_path).download(root=tmpdir)
+            if idx % 50 == 0 or idx == total_files:
+                print(f"[blend] Downloaded {idx}/{total_files}: {rel_path}")
+            if sleep_sec and sleep_sec > 0:
+                time.sleep(sleep_sec)
+
+        # テーブルJSONを読み込み
+        table_json_path = Path(tmpdir) / f"{table_name}.table.json"
+        with table_json_path.open("r") as f:
+            tjs = json.load(f)
+
+    # DataFrame化（Media実体はローカルに順次ダウン済み）
+    output_df = pd.DataFrame(data=tjs.get("data", []), columns=tjs.get("columns", []))
+    print(f"[blend] Completed: {artifact_path}")
+    return output_df
 
 def cleanup_gpu():
     """


### PR DESCRIPTION
- 背景
  - Alibaba Cloud Model Studio（DashScope）経由のQwen3-Max-PreviewをBFCLで評価できるようにする必要がありました。
  - blend runで多数のベンチマークの結果を再取り込み（resume）する際、W&Bアーティファクトの大量並列ダウンロードが原因でネットワーク周りが不安定になりがちでした。これはNejumi3と比較してベンチマーク数が大きく増加していることに起因していました。

- 変更点
  - BFCL/Qwen対応
    - Qwen3‑Max‑Preview用ハンドラーを追加（国際エンドポイントを使用）
    - OPENAI_COMPATIBLE_API_KEYに統一
    - `SUPPORTED_MODELS.md`と`model_config`に登録
    - 設定ファイル `configs/config-qwen-qwen3-max.yaml` を追加（bfcl_model_id: qwen3-max-preview-FC）
  - コンテンツフィルタ耐性
    - `llm_inference_adapter.py`（sync/async）でDashScopeの`data_inspection_failed`を検出し、プレースホルダーを返して処理継続
    - `LLMResponse`の引数名を`parsed_output`に統一して例外を解消
  - blend再開の堅牢化
    - `read_wandb_table_throttled()`を追加し、アーティファクトを逐次ダウンロード（軽いスリープ＋進捗ログ）に変更
    - `Artifact.get_path`→`get_entry`に置き換えて非推奨警告を解消
    - 大規模アーティファクトでもコネクションプール枯渇や署名付きURL失効のリスクを低減
  - 細かな改善
    - Qwen国際クライアントのextra_body整備、ストリーミング処理の一貫性を確保

- 影響範囲
  - BFCLでQwen3‑Max‑Previewを新規サポート
  - blend runの再開処理のみダウンロード手法を変更（取得内容は従来通りフル）し、他の評価フローには影響なし

- 動作確認
  - Qwen3‑Max‑PreviewでBFCLの単発・マルチターン実行が完了することを確認
  - M_IFEVAL / JASTERでコンテンツフィルタエラーが発生しても処理が継続することを確認
  - blend runでアーティファクト逐次ダウンロードの進捗ログが出力され、ダウンロードが安定することを確認
  - Qwen/Qwen3-Max-Preview: [W&B Run](https://wandb.ai/llm-leaderboard/nejumi-leaderboard4/runs/as6t689r)

- 環境変数
  - `OPENAI_COMPATIBLE_API_KEY`: DashScope（国際）APIキーを設定
  - `base_url`: `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`
