### PR TITLE
Add Opus 4.7 and DeepSeek V4 Pro eval configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-１# Byte-compiled / optimized / DLL files
+# Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 *$py.class
@@ -125,6 +125,15 @@ fastchat/llm_judge/data/japanese_mt_bench
 hallulens_output_table.table.json
 wandb_export_*.csv
 .codex
+
+# evaluation outputs
+/generation*.jsonl
+/predictions/
+
+# local sandbox runtime data
+/volumes/sandbox/*
+!/volumes/sandbox/dependencies/
+!/volumes/sandbox/dependencies/python-requirements.txt
 
 # vllm
 *.pid

--- a/configs/config-anthropic-claude-opus-4-7-openrouter.yaml
+++ b/configs/config-anthropic-claude-opus-4-7-openrouter.yaml
@@ -1,0 +1,84 @@
+wandb:
+  run_name: "anthropic/claude-opus-4.7: adaptive-thinking-xhigh"
+api: openai-compatible # openai, anthropic, google,..
+base_url: https://openrouter.ai/api/v1
+batch_size: 32
+model:
+  pretrained_model_name_or_path: anthropic/claude-opus-4.7
+  bfcl_model_id: OpenRouter-FC
+  base_model: "unknown"
+  size_category: api
+  size: null
+  release_date: 4/16/2026
+
+generator:
+  # Claude Opus 4.7 rejects/ignores sampling controls; null values are omitted by the client.
+  temperature: null
+  top_p: null
+  parallel_tool_calls: true
+  max_tokens: 128000
+  extra_body:
+    # Opus 4.7 only supports adaptive thinking; fixed budget_tokens/max_tokens are ignored or rejected.
+    reasoning:
+      enabled: true
+    # OpenRouter maps this to Anthropic output_config.effort.
+    verbosity: xhigh
+
+jaster:
+  override_max_tokens: 128000
+
+jbbq:
+  generator_config:
+    max_tokens: 128000
+
+toxicity:
+  generator_config:
+    max_tokens: 128000
+    temperature: null
+    top_p: null
+
+jtruthfulqa:
+  generator_config:
+    max_tokens: 128000
+
+mtbench:
+  max_new_token: 128000
+  generator_config:
+    max_tokens: 128000
+    temperature: null
+  temperature_override:
+    writing: null
+    roleplay: null
+    extraction: null
+    math: null
+    coding: null
+    reasoning: null
+    stem: null
+    humanities: null
+
+bfcl:
+  generator_config:
+    max_tokens: 128000
+    temperature: null
+    top_p: null
+
+hallulens:
+  generator_config:
+    max_tokens: 128000
+    temperature: null
+    top_p: null
+
+hle:
+  max_completion_tokens: 128000
+  generator_config:
+    max_tokens: 128000
+
+arc_agi:
+  max_output_tokens: 128000
+
+m_ifeval:
+  generator_config:
+    max_tokens: 128000
+
+swebench:
+  max_tokens: 128000

--- a/configs/config-deepseek-v4-pro.yaml
+++ b/configs/config-deepseek-v4-pro.yaml
@@ -1,0 +1,100 @@
+wandb:
+  run_name: "deepseek/deepseek-v4-pro: thinking-max"
+
+api: deepseek
+base_url: https://api.deepseek.com
+batch_size: 32
+
+model:
+  pretrained_model_name_or_path: deepseek-v4-pro
+  bfcl_model_id: DeepSeek-V4-Pro-FC
+  base_model: "unknown"
+  size_category: api
+  size: 1600000000000
+  release_date: 4/24/2026
+
+generator:
+  # DeepSeek V4 thinking mode ignores sampling controls; null values are omitted by the client.
+  temperature: null
+  top_p: null
+  max_tokens: 384000
+  reasoning_effort: max
+  extra_body:
+    thinking:
+      type: enabled
+
+jaster:
+  override_max_tokens: 384000
+
+jbbq:
+  generator_config:
+    max_tokens: 384000
+
+toxicity:
+  generator_config:
+    max_tokens: 384000
+    temperature: null
+    top_p: null
+
+jtruthfulqa:
+  generator_config:
+    max_tokens: 384000
+
+mtbench:
+  max_new_token: 384000
+  generator_config:
+    max_tokens: 384000
+    temperature: null
+    top_p: null
+    reasoning_effort: max
+    extra_body:
+      thinking:
+        type: enabled
+  temperature_override:
+    writing: null
+    roleplay: null
+    extraction: null
+    math: null
+    coding: null
+    reasoning: null
+    stem: null
+    humanities: null
+
+bfcl:
+  generator_config:
+    max_tokens: 384000
+    temperature: null
+    top_p: null
+    reasoning_effort: max
+    extra_body:
+      thinking:
+        type: enabled
+
+hallulens:
+  generator_config:
+    max_tokens: 384000
+    temperature: null
+    top_p: null
+    reasoning_effort: max
+    extra_body:
+      thinking:
+        type: enabled
+
+hle:
+  max_completion_tokens: 384000
+  generator_config:
+    max_tokens: 384000
+    reasoning_effort: max
+    extra_body:
+      thinking:
+        type: enabled
+
+arc_agi:
+  max_output_tokens: 384000
+
+m_ifeval:
+  generator_config:
+    max_tokens: 384000
+
+swebench:
+  max_tokens: 384000

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md
@@ -58,6 +58,7 @@ These unified handlers eliminate the need to configure individual model-specific
 | DeepSeek-V3-0324                               | Function Calling | DeepSeek       | DeepSeek-V3-0324-FC                                         |
 | DeepSeek-V3-0324                               | Prompt           | Self-hosted 💻 | deepseek-ai/DeepSeek-V3-0324                                |
 | DeepSeek-V3.1                                  | Function Calling | DeepSeek       | DeepSeek-V3.1-FC                                            |
+| DeepSeek-V4-Pro                                | Function Calling | DeepSeek       | DeepSeek-V4-Pro-FC                                          |
 | Falcon3-{1B,3B,7B,10B}-Instruct                | Function Calling | Self-hosted 💻 | tiiuae/Falcon3-{1B,3B,7B,10B}-Instruct                      |
 | FireFunction-v2                                | Function Calling | Fireworks AI   | firefunction-v2-FC                                          |
 | Functionary-{Small,Medium}-v3.1                | Function Calling | MeetKai        | meetkai/functionary-{small,medium}-v3.1-FC                  |

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/constants/model_config.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/constants/model_config.py
@@ -4,7 +4,7 @@ from typing import Optional
 from ..model_handler.api_inference.claude import ClaudeHandler
 from ..model_handler.api_inference.cohere import CohereHandler
 from ..model_handler.api_inference.databricks import DatabricksHandler
-from ..model_handler.api_inference.deepseek import DeepSeekAPIHandler, DeepSeekV32APIHandler
+from ..model_handler.api_inference.deepseek import DeepSeekAPIHandler, DeepSeekV32APIHandler, DeepSeekV4APIHandler
 #from ..model_handler.api_inference.dm_cito import DMCitoHandler
 from ..model_handler.api_inference.fireworks import FireworksHandler
 from ..model_handler.api_inference.functionary import FunctionaryHandler
@@ -218,6 +218,18 @@ api_inference_model_map = {
         model_handler=DeepSeekAPIHandler,
         input_price=0.28,
         output_price=0.42,
+        is_fc_model=True,
+        underscore_to_dot=True,
+    ),
+    "DeepSeek-V4-Pro-FC": ModelConfig(
+        model_name="DeepSeek-V4-Pro-FC",
+        display_name="DeepSeek-V4-Pro (FC, Thinking)",
+        url="https://api-docs.deepseek.com/news/news260424",
+        org="DeepSeek",
+        license="DeepSeek License",
+        model_handler=DeepSeekV4APIHandler,
+        input_price=0.435,
+        output_price=0.87,
         is_fc_model=True,
         underscore_to_dot=True,
     ),

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/constants/supported_models.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/constants/supported_models.py
@@ -20,6 +20,7 @@ SUPPORTED_MODELS = [
     "DeepSeek-V3.1-FC",
     "DeepSeek-V3.2-FC",
     "DeepSeek-V3.2-NonThinking-FC",
+    "DeepSeek-V4-Pro-FC",
     "gpt-4.5-preview-2025-02-27",
     "gpt-4.5-preview-2025-02-27-FC",
     "gpt-5.4-2026-03-05-FC",

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/api_inference/deepseek.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/api_inference/deepseek.py
@@ -1,6 +1,7 @@
 import json
 import os
 import time
+import copy
 
 from omegaconf import OmegaConf
 from .openai_completion import OpenAICompletionsHandler
@@ -15,9 +16,30 @@ from openai import OpenAI, RateLimitError
 from overrides import override
 
 try:
-    from scripts.wandb_singleton import WandbConfigSingleton
+    from config_singleton import WandbConfigSingleton
 except ImportError:
     WandbConfigSingleton = None
+
+
+def _to_plain_dict(value):
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return copy.deepcopy(value)
+    try:
+        return OmegaConf.to_container(value, resolve=True) or {}
+    except Exception:
+        return {}
+
+
+def _deep_merge_dicts(base: dict, override: dict) -> dict:
+    merged = copy.deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge_dicts(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
 
 
 class DeepSeekAPIHandler(OpenAICompletionsHandler):
@@ -25,8 +47,84 @@ class DeepSeekAPIHandler(OpenAICompletionsHandler):
         super().__init__(model_name, temperature)
         self.model_style = ModelStyle.OpenAI_Completions
         self.client = OpenAI(
-            base_url="https://api.deepseek.com", api_key=os.getenv("OPENAI_COMPATIBLE_API_KEY")
+            base_url="https://api.deepseek.com",
+            api_key=os.getenv("DEEPSEEK_API_KEY")
+            or os.getenv("OPENAI_COMPATIBLE_API_KEY"),
         )
+        self.cfg = self._load_cfg()
+        self.generator_config = self._load_generator_config()
+
+    @staticmethod
+    def _load_cfg():
+        if WandbConfigSingleton is None:
+            return None
+        try:
+            return WandbConfigSingleton.get_instance().config
+        except Exception:
+            return None
+
+    def _load_generator_config(self) -> dict:
+        if self.cfg is None:
+            return {}
+        return _deep_merge_dicts(
+            _to_plain_dict(getattr(self.cfg, "generator", {})),
+            _to_plain_dict(getattr(getattr(self.cfg, "bfcl", {}), "generator_config", {})),
+        )
+
+    def _configured_api_model_name(self) -> str:
+        if self.cfg is not None:
+            try:
+                model_name = str(self.cfg.model.pretrained_model_name_or_path)
+                if model_name in {"deepseek-v4-pro", "deepseek-v4-flash"}:
+                    return model_name
+            except Exception:
+                pass
+
+        if "DeepSeek-V4-Pro" in self.model_name:
+            return "deepseek-v4-pro"
+        if "DeepSeek-V4-Flash" in self.model_name:
+            return "deepseek-v4-flash"
+        if "DeepSeek-V3" in self.model_name:
+            return "deepseek-chat"
+        if "DeepSeek-R1" in self.model_name:
+            return "deepseek-reasoner"
+
+        raise ValueError(f"Model name {self.model_name} not yet supported")
+
+    def _build_generation_kwargs(self, *, include_tools: bool = False, tools=None) -> dict:
+        kwargs = {}
+        for key, value in self.generator_config.items():
+            if value is None:
+                continue
+            if key == "parallel_tool_calls":
+                continue
+            kwargs[key] = value
+
+        if "max_tokens" not in kwargs:
+            kwargs["max_tokens"] = 8192
+
+        thinking_cfg = kwargs.get("extra_body", {}).get("thinking") if isinstance(kwargs.get("extra_body"), dict) else None
+        thinking_enabled = (
+            isinstance(thinking_cfg, dict)
+            and thinking_cfg.get("type", "enabled") == "enabled"
+        )
+        if thinking_enabled:
+            # DeepSeek thinking mode ignores these parameters; omit them to keep requests clean.
+            for key in ("temperature", "top_p", "presence_penalty", "frequency_penalty"):
+                kwargs.pop(key, None)
+        else:
+            kwargs.setdefault("temperature", self.temperature)
+
+        if include_tools and tools:
+            kwargs["tools"] = tools
+
+        return kwargs
+
+    def _add_reasoning_content_if_available(self, api_response: any, response_data: dict) -> None:
+        if "FC" in self.model_name or self.is_fc_model:
+            self._add_reasoning_content_if_available_FC(api_response, response_data)
+        else:
+            self._add_reasoning_content_if_available_prompting(api_response, response_data)
 
     # The deepseek API is unstable at the moment, and will frequently give empty responses, so retry on JSONDecodeError is necessary
     @retry_with_backoff(error_type=[RateLimitError, json.JSONDecodeError])
@@ -52,30 +150,14 @@ class DeepSeekAPIHandler(OpenAICompletionsHandler):
         tools = inference_data["tools"]
         inference_data["inference_input_log"] = {"message": repr(message), "tools": tools}
 
-        # Source https://api-docs.deepseek.com/quick_start/pricing
-        # This will need to be updated if newer models are released.
-        if "DeepSeek-V3" in self.model_name:
-            api_model_name = "deepseek-chat"
-        elif "DeepSeek-R1" in self.model_name:
-            api_model_name = "deepseek-reasoner"
-        else:
-            raise ValueError(
-                f"Model name {self.model_name} not yet supported in this method"
-            )
+        api_model_name = self._configured_api_model_name()
+        kwargs = {
+            "model": api_model_name,
+            "messages": message,
+            **self._build_generation_kwargs(include_tools=True, tools=tools),
+        }
 
-        if len(tools) > 0:
-            return self.generate_with_backoff(
-                model=api_model_name,
-                messages=message,
-                tools=tools,
-                temperature=self.temperature,
-            )
-        else:
-            return self.generate_with_backoff(
-                model=api_model_name,
-                messages=message,
-                temperature=self.temperature,
-            )
+        return self.generate_with_backoff(**kwargs)
 
     @override
     def _query_prompting(self, inference_data: dict):
@@ -91,16 +173,12 @@ class DeepSeekAPIHandler(OpenAICompletionsHandler):
         message: list[dict] = inference_data["message"]
         inference_data["inference_input_log"] = {"message": repr(message)}
 
-        if "DeepSeek-R1" in self.model_name:
-            api_model_name = "deepseek-reasoner"
-        else:
-            raise ValueError(
-                f"Model name {self.model_name} not yet supported in this method"
-            )
+        api_model_name = self._configured_api_model_name()
 
         return self.generate_with_backoff(
             model=api_model_name,
             messages=message,
+            **self._build_generation_kwargs(),
         )
 
     @override
@@ -139,27 +217,8 @@ class DeepSeekV32APIHandler(DeepSeekAPIHandler):
     
     def __init__(self, model_name, temperature) -> None:
         super().__init__(model_name, temperature)
-        self.thinking_param = None
-        
-        # Load reasoning config from WandbConfigSingleton if available
-        if WandbConfigSingleton is not None:
-            try:
-                instance = WandbConfigSingleton.get_instance()
-                cfg = instance.config
-                gen_cfg = getattr(cfg, "generator", {})
-                
-                # OmegaConf.DictConfig を dict に変換
-                if hasattr(OmegaConf, "to_container") and not isinstance(gen_cfg, dict):
-                    gen_cfg = OmegaConf.to_container(gen_cfg)
-                
-                extra_body = gen_cfg.get("extra_body", {}) if isinstance(gen_cfg, dict) else {}
-                # DeepSeek uses 'thinking' parameter
-                thinking = extra_body.get("thinking") if isinstance(extra_body, dict) else None
-                
-                if thinking is not None:
-                    self.thinking_param = thinking
-            except Exception:
-                pass
+        extra_body = self.generator_config.get("extra_body", {})
+        self.thinking_param = extra_body.get("thinking") if isinstance(extra_body, dict) else None
     
     @override
     def _query_FC(self, inference_data: dict):
@@ -167,29 +226,27 @@ class DeepSeekV32APIHandler(DeepSeekAPIHandler):
         tools = inference_data["tools"]
         inference_data["inference_input_log"] = {"message": repr(message), "tools": tools}
         
-        # DeepSeek V3.2 Thinking Mode uses "deepseek-reasoner"
-        # Non-thinking Mode uses "deepseek-chat"
-        # See: https://api-docs.deepseek.com/quick_start/pricing
-        if self.thinking_param is not None:
-            api_model_name = "deepseek-reasoner"
-        else:
-            api_model_name = "deepseek-chat"
-        
+        api_model_name = self._configured_api_model_name()
+        if api_model_name not in {"deepseek-v4-pro", "deepseek-v4-flash"}:
+            # Compatibility aliases used by older DeepSeek configs.
+            api_model_name = "deepseek-reasoner" if self.thinking_param is not None else "deepseek-chat"
+
         kwargs = {
             "model": api_model_name,
             "messages": message,
+            **self._build_generation_kwargs(include_tools=True, tools=tools),
         }
-        
-        if len(tools) > 0:
-            kwargs["tools"] = tools
-        
-        # Add thinking parameter if configured
-        if self.thinking_param is not None:
-            kwargs["extra_body"] = {"thinking": self.thinking_param}
-        
-        # deepseek-reasoner doesn't support temperature parameter
-        # Only add temperature for non-reasoning mode
-        if api_model_name == "deepseek-chat":
-            kwargs["temperature"] = self.temperature
-        
+
         return self.generate_with_backoff(**kwargs)
+
+
+class DeepSeekV4APIHandler(DeepSeekV32APIHandler):
+    """Handler for official DeepSeek V4 API in function-calling thinking mode."""
+
+    @override
+    def _parse_query_response_FC(self, api_response: any) -> dict:
+        response_data = OpenAICompletionsHandler._parse_query_response_FC(self, api_response)
+        message = api_response.choices[0].message
+        if hasattr(message, "reasoning_content") and message.reasoning_content:
+            response_data["reasoning_content"] = message.reasoning_content
+        return response_data

--- a/scripts/llm_inference_adapter.py
+++ b/scripts/llm_inference_adapter.py
@@ -250,7 +250,7 @@ def _parse_tool_call_arguments(arguments: Any, *, strict: bool = True) -> Dict[s
 
 def filter_params(params, allowed_params):
     """許可されたパラメータのみをフィルタリング"""
-    return {k: v for k, v in params.items() if k in allowed_params}
+    return {k: v for k, v in params.items() if k in allowed_params and v is not None}
 
 
 def map_common_params(params, param_mapping):
@@ -553,7 +553,7 @@ class OpenAIClient:
             'n', 'presence_penalty', 'response_format', 'seed', 'stop',
             'stream', 'temperature', 'top_p', 'tools', 'tool_choice',
             'user', 'extra_body', 'functions', 'function_call',
-            'parallel_tool_calls'
+            'parallel_tool_calls', 'reasoning_effort'
         }
         
         self.param_mapping = {}
@@ -1667,6 +1667,17 @@ def get_llm_inference_engine() -> BaseLLMClient:
         llm = OpenAIClient(
             api_key=os.environ["XAI_API_KEY"],
             base_url="https://api.x.ai/v1",
+            model=cfg.model.pretrained_model_name_or_path,
+            **cfg.generator,
+        )
+
+    elif api_type == "deepseek":
+        llm = OpenAIClient(
+            api_key=os.environ.get(
+                "DEEPSEEK_API_KEY",
+                os.environ.get("OPENAI_COMPATIBLE_API_KEY", "EMPTY"),
+            ),
+            base_url=cfg.get("base_url", "https://api.deepseek.com"),
             model=cfg.model.pretrained_model_name_or_path,
             **cfg.generator,
         )


### PR DESCRIPTION
Add Opus 4.7 and DeepSeek V4 Pro eval configs

## Summary
- Add OpenRouter config for `anthropic/claude-opus-4.7`
- Add official DeepSeek API config for `deepseek-v4-pro`
- Register `DeepSeek-V4-Pro-FC` for BFCL
- Pass `reasoning_effort` through OpenAI-compatible requests
- Ignore local evaluation outputs

## Verification
- YAML syntax checked
- Python source syntax checked with `compile()`
- Branch pushed to GitHub
